### PR TITLE
Increased tooltip font size

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,6 +23,13 @@ function App() {
 		shape: {
 			borderRadius: '10px',
 		},
+		overrides: {
+			MuiTooltip: {
+				tooltip: {
+					fontSize: '1.1em',
+				},
+			},
+		},
 	});
 
 	return (


### PR DESCRIPTION
This commit will Increase the font size of all tooltips to 1.1em, previous font size was too small so this should be much more readable.